### PR TITLE
Create upload picture button without backend

### DIFF
--- a/easyartshow/package-lock.json
+++ b/easyartshow/package-lock.json
@@ -8,6 +8,7 @@
       "name": "easyartshow",
       "version": "0.1.0",
       "dependencies": {
+        "@firebase/auth": "^0.21.3",
         "@google-cloud/secret-manager": "^4.2.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/easyartshow/package.json
+++ b/easyartshow/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@firebase/auth": "^0.21.3",
     "@google-cloud/secret-manager": "^4.2.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/easyartshow/src/firebase.js
+++ b/easyartshow/src/firebase.js
@@ -1,6 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
+
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 

--- a/easyartshow/src/screens/participant/uploadPicRoom.js
+++ b/easyartshow/src/screens/participant/uploadPicRoom.js
@@ -1,14 +1,35 @@
-import React from 'react'
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-function UploadPicRoom() {
-    const navigate = useNavigate();
-    return (
-      <div>
-        Upload picture: <input type="file" />
-        <button onClick={() => navigate('/waitingroom')}>Upload</button>
-      </div>
-    );
-  }
-  
+const UploadPicRoom = () => {
+  const [picture, setPicture] = useState(null);
+  const [progress, setProgress] = useState(0);
+  const [imageUrl, setImageUrl] = useState("");
+  const navigate = useNavigate();
+
+  const handlePictureChange = (e) => {
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImageUrl(reader.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div>
+      Choose a picture:
+      <input type="file" onChange={handlePictureChange} />
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt="Selected"
+          style={{ width: "150px", height: "150px" }}
+        />
+      )}
+      <div>{progress}%</div>
+    </div>
+  );
+};
+
 export default UploadPicRoom;


### PR DESCRIPTION
# Create upload picture button without backend

## Description
When you upload the picture, the preview of it will be shown on the front-end. Not much done in Firebase backend yet. 

## Reviewer instructions
Run the site locally, go to localhost:3000/uploadpicroom, try to upload any pictures. 

## Additional context
Will add Firebase later

## Screenshots/GIFs

<img width="682" alt="Screenshot 2023-02-24 at 1 06 23 PM" src="https://user-images.githubusercontent.com/32094007/221269395-55f6bd7e-e7c7-4bd3-8c92-a837153689ba.png">
